### PR TITLE
feat(useFragment): refactor API with new overload, deprecate legacy options format

### DIFF
--- a/.changeset/refactor-usefragment-options.md
+++ b/.changeset/refactor-usefragment-options.md
@@ -1,0 +1,15 @@
+---
+"@vue3-apollo/core": minor
+---
+
+feat(core): refactor `useFragment` API and split option types
+
+- New overload: `useFragment(document, options?)` (recommended)
+- Introduce `UseFragmentOptions<TData, TVariables>` (no `fragment`)
+- Add `UseLegacyFragmentOptions<TData, TVariables>` extending the new options with `fragment` — deprecated
+- Keep legacy overload `useFragment({ fragment, ... })` for backward compatibility
+- Update docs to reflect the new API
+
+Migration
+- Prefer `useFragment(document, options?)`
+- Adopt `UseFragmentOptions`; legacy type/overload will be removed in a future major

--- a/packages/docs/composables/useFragment.md
+++ b/packages/docs/composables/useFragment.md
@@ -32,7 +32,7 @@ This composable automatically tracks and updates when the underlying cache data 
 ### Returns
 - **`result`** – Full fragment result including `data`, `complete`, and `missing` information. Ideal for TypeScript narrowing.
   ```ts
-  const { result } = useFragment<User>(...)
+  const { result } = useFragment<User>(USER_FRAGMENT, { from: 'User:1' })
 
   if (result.value?.complete) {
     console.log(result.value.data.name) // ✅ Fully typed
@@ -60,16 +60,31 @@ This composable automatically tracks and updates when the underlying cache data 
   })
   ```
 
-### Options
+### Options (new API)
 - **`from`** – *string | object | Ref | getter* (**required**). The source entity to read from cache. Accepts:
   - A cache ID string (e.g., `'User:1'`).
   - An entity object with `__typename` and an identifier.
   - A reactive ref or computed getter returning one of the above.
 - **`variables`** – *Record<string, any> | Ref | getter*. Fragment variables (for fragments with `@arguments`).
+- **`fragmentName`** – *string | Ref | getter*. Required only if the provided document contains multiple fragments.
 - **`enabled`** – *boolean | Ref | getter* (default: `true`). Enables or disables fragment watching.
 - **`optimistic`** – *boolean* (default: `true`). Include optimistic layer when reading from cache.
 - **`prefetch`** – *boolean* (default: `true`). For SSR: prefetch fragment data during server rendering to avoid hydration flicker.
 - **`clientId`** – *string*. Apollo client identifier if multiple clients are registered.
+
+#### Overloads
+- New (recommended): `useFragment(document, options?)`
+- Legacy (deprecated, still supported): `useFragment({ fragment, ...options })`
+
+#### Legacy usage (deprecated)
+```ts
+// Prefer the new API above. This legacy form remains for backward compatibility.
+const { result } = useFragment({
+  fragment: USER_FRAGMENT,
+  from: { __typename: 'User', id: '123' },
+  fragmentName: 'UserFragment'
+})
+```
 
 ## Notes
 - Watching is based on **reference equality** of `from` and `variables`. Changing references will re-subscribe.
@@ -77,3 +92,7 @@ This composable automatically tracks and updates when the underlying cache data 
 - `data` is exposed as **`DeepPartial<TData>`** since fragments can be partial.
 - Recommended: Use `result` for best TypeScript type narrowing.
 - For SSR, keep `prefetch: true` for smoother hydration.
+
+## Types
+- `UseFragmentOptions<TData, TVariables>`: Options type for the new API (no `fragment` field).
+- `UseLegacyFragmentOptions<TData, TVariables>`: Extends `UseFragmentOptions` and adds `fragment`. Deprecated — prefer the new API.

--- a/packages/web/src/App.vue
+++ b/packages/web/src/App.vue
@@ -36,8 +36,7 @@ onOptimistic((data) => {
     console.warn('onOptimistic', data)
 })
 
-const { data } = useFragment({
-    fragment: PostDetailFragmentDoc,
+const { data } = useFragment(PostDetailFragmentDoc, {
     from: {
         __typename: 'Post',
         id: 1


### PR DESCRIPTION
…ptions format

- Added `useFragment(document, options?)` overload (recommended).
- Deprecated legacy `{ fragment, ...options }` usage.
- Introduced `UseFragmentOptions` type and deprecated legacy types.
- Updated docs and codebase to follow the new API.
- Maintained backward compatibility for migration.