### PR TITLE
chore: add changeset for useQuery loading/lifecycle fix

### DIFF
--- a/.changeset/fix-usequery-loading-lifecycle.md
+++ b/.changeset/fix-usequery-loading-lifecycle.md
@@ -1,0 +1,11 @@
+---
+"@vue3-apollo/core": patch
+---
+
+Fix `useQuery` loading and lifecycle handling:
+
+- Reset `loading` in the error handler so it no longer sticks `true` after an observable error terminates the subscription (default `errorPolicy`).
+- Make `start()` idempotent so it never orphans a previous `ObservableQuery` (preventing a leak and a missing observer).
+- Clear `loading` on `refetch`/`fetchMore` rejection.
+- Set `loading` on reactive variable changes and swallow `setVariables` rejections to avoid unhandled promises.
+- Reset `networkStatus` in `stop()`.


### PR DESCRIPTION
## Context

PR #69 merged the `useQuery` loading/lifecycle fix into `main` but **forgot to include a changeset**, so the change would be missing from the next release/version bump.

This PR adds the missing changeset. Since the fix commits are already on `main`, the diff here is **just the single changeset file**.

## Changes

Adds `.changeset/fix-usequery-loading-lifecycle.md` → `@vue3-apollo/core: patch`, describing the fixes:

- Reset `loading` in the error handler so it no longer sticks `true` after an observable error terminates the subscription (default `errorPolicy`).
- Make `start()` idempotent so it never orphans a previous `ObservableQuery` (preventing a leak and a missing observer).
- Clear `loading` on `refetch`/`fetchMore` rejection.
- Set `loading` on reactive variable changes and swallow `setVariables` rejections to avoid unhandled promises.
- Reset `networkStatus` in `stop()`.

Once merged, the Changesets bot will update the "Version Packages" PR and bump `@vue3-apollo/core` to the next patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)