### PR TITLE
feat(core): add called flag to useQuery

### DIFF
--- a/.changeset/unify-lazyquery-called.md
+++ b/.changeset/unify-lazyquery-called.md
@@ -1,0 +1,7 @@
+---
+"@vue3-apollo/core": patch
+---
+
+Unify `useLazyQuery`'s `called` flag with `useQuery`.
+
+`useLazyQuery` now reuses the `called` ref exposed by `useQuery` instead of tracking its own, so both composables share a single source of truth. There is no behavior change: `execute()` still flips `called` to `true` synchronously on the first call.

--- a/.changeset/usequery-called-flag.md
+++ b/.changeset/usequery-called-flag.md
@@ -4,6 +4,4 @@
 
 Add a `called` flag to `useQuery`.
 
-`useQuery` now returns a sticky `called` ref that becomes `true` the first time the query actually starts fetching (SSR prefetch or client-side observer) and stays `true` across `stop()`/`start()` cycles. This makes it easy to tell "never fetched yet" apart from "fetched at least once" on the UI — for example to show an initial placeholder before the first request, or to gate an empty state until data has actually been requested.
-
-`useLazyQuery` now reuses this same `called` ref instead of tracking its own, so both composables share a single source of truth. The manual-trigger semantics are unchanged: `execute()` still flips `called` to `true` synchronously.
+`useQuery` now returns a sticky `called` ref that becomes `true` the first time the query actually starts fetching (SSR prefetch or client-side observer) and stays `true` across `stop()`/`start()` cycles. This makes it easy to tell "never fetched yet" apart from "fetched at least once" on the UI — for example to show an initial placeholder before the first request, or to gate an empty state until data has actually been requested. The naming mirrors the existing `called` in `useLazyQuery`.

--- a/.changeset/usequery-called-flag.md
+++ b/.changeset/usequery-called-flag.md
@@ -4,4 +4,6 @@
 
 Add a `called` flag to `useQuery`.
 
-`useQuery` now returns a sticky `called` ref that becomes `true` the first time the query actually starts fetching (SSR prefetch or client-side observer) and stays `true` across `stop()`/`start()` cycles. This makes it easy to tell "never fetched yet" apart from "fetched at least once" on the UI — for example to show an initial placeholder before the first request, or to gate an empty state until data has actually been requested. The naming mirrors the existing `called` in `useLazyQuery`.
+`useQuery` now returns a sticky `called` ref that becomes `true` the first time the query actually starts fetching (SSR prefetch or client-side observer) and stays `true` across `stop()`/`start()` cycles. This makes it easy to tell "never fetched yet" apart from "fetched at least once" on the UI — for example to show an initial placeholder before the first request, or to gate an empty state until data has actually been requested.
+
+`useLazyQuery` now reuses this same `called` ref instead of tracking its own, so both composables share a single source of truth. The manual-trigger semantics are unchanged: `execute()` still flips `called` to `true` synchronously.

--- a/.changeset/usequery-called-flag.md
+++ b/.changeset/usequery-called-flag.md
@@ -1,0 +1,7 @@
+---
+"@vue3-apollo/core": minor
+---
+
+Add a `called` flag to `useQuery`.
+
+`useQuery` now returns a sticky `called` ref that becomes `true` the first time the query actually starts fetching (SSR prefetch or client-side observer) and stays `true` across `stop()`/`start()` cycles. This makes it easy to tell "never fetched yet" apart from "fetched at least once" on the UI — for example to show an initial placeholder before the first request, or to gate an empty state until data has actually been requested. The naming mirrors the existing `called` in `useLazyQuery`.

--- a/packages/core/src/composables/useLazyQuery.ts
+++ b/packages/core/src/composables/useLazyQuery.ts
@@ -92,13 +92,15 @@ export function useLazyQuery<
     variables?: MaybeRefOrGetter<TVariables>,
     options?: UseLazyQueryOptions<TData, TVariables>
 ): ReturnType<typeof useQuery<TData, TVariables>> & UseLazyQueryReturn<TData, TVariables> {
-    const called = ref(false)
     const enabled = ref(false)
     const executeVariables = ref<TVariables>()
 
     const reactiveVariables = computed(() => executeVariables.value ?? toValue(variables) ?? {} as TVariables)
 
-    const { query, start, ...rest } = useQuery<TData, TVariables>(
+    // Reuse useQuery's `called` flag instead of tracking a second one. `execute()`
+    // writes to it synchronously below, so the manual-trigger semantics are kept
+    // while there is a single source of truth shared with the underlying query.
+    const { called, query, start, ...rest } = useQuery<TData, TVariables>(
         document,
         reactiveVariables,
         {

--- a/packages/core/src/composables/useQuery.ts
+++ b/packages/core/src/composables/useQuery.ts
@@ -170,6 +170,12 @@ export function useQuery<TData = unknown, TVariables extends OperationVariables 
     const networkStatus = ref<NetworkStatus>()
     const error = ref<ErrorLike>()
 
+    // Sticky flag: becomes true the first time the query actually starts fetching
+    // (either an SSR prefetch or a client-side observer). Stays true afterwards,
+    // even across stop()/start() cycles, so the UI can tell "never fetched yet"
+    // apart from "fetched at least once".
+    const called = ref(false)
+
     const onResultEvent = createEventHook<[TData, HookContext]>()
     const onErrorEvent = createEventHook<[ErrorLike, HookContext]>()
 
@@ -195,6 +201,7 @@ export function useQuery<TData = unknown, TVariables extends OperationVariables 
     const prefetch = options?.prefetch ?? true
     if (prefetch && enabled.value && isServer()) {
         onServerPrefetch(async () => {
+            called.value = true
             try {
                 const queryResult = await client.query<TData, TVariables>({
                     ...queryOptions,
@@ -289,6 +296,9 @@ export function useQuery<TData = unknown, TVariables extends OperationVariables 
         if (!enabled.value || query.value) {
             return
         }
+
+        // Past the guard we are committed to fetching: mark the query as called.
+        called.value = true
 
         // Check if we have cached data from SSR on the client-side
         if (!isServer()) {
@@ -408,6 +418,30 @@ export function useQuery<TData = unknown, TVariables extends OperationVariables 
     }
 
     return {
+        /**
+         * Whether the query has started fetching at least once.
+         * Becomes `true` the first time the query executes (SSR prefetch or
+         * client-side observer) and stays `true` afterwards, even across
+         * `stop()`/`start()` cycles.
+         *
+         * Useful in the UI to distinguish "never fetched yet" from
+         * "fetched at least once" — for example to show an initial placeholder
+         * before the first request, or to gate an empty state until data has
+         * actually been requested.
+         *
+         * @example
+         * ```ts
+         * const { called, loading, result } = useQuery(MY_QUERY, vars, { enabled })
+         *
+         * // Skeleton only on the very first load, not on later refetches
+         * const showSkeleton = computed(() => loading.value && !called.value)
+         *
+         * // Empty state only after the query has actually run
+         * const showEmpty = computed(() => called.value && !loading.value && !result.value)
+         * ```
+         */
+        called,
+
         /**
          * GraphQL error if the query failed.
          * Includes both network errors and GraphQL errors.

--- a/packages/docs/composables/useQuery.md
+++ b/packages/docs/composables/useQuery.md
@@ -48,6 +48,7 @@ function useQuery<TData, TVariables>(
 ## Returns
 - `result`: Reactive query data.
 - `loading`: Query loading state.
+- `called`: Whether the query has started fetching at least once. Sticky `true` once the first request runs (SSR prefetch or client observer), kept across `stop()`/`start()`. Useful to tell "never fetched yet" from "fetched at least once" on the UI.
 - `error`: Last query error.
 - `networkStatus`: Apollo `NetworkStatus` value.
 - `onResult((data, context) => void)`: Fired when data is available.
@@ -143,6 +144,24 @@ const isAnyLoading = useQueriesLoading(loadingKey)
 ```
 
 Use this when one place in UI (for example spinner in component B) should react to loading states triggered by multiple query owners (A and B).
+
+### Case 5: First-load placeholder vs empty state with `called`
+
+```ts
+const enabled = ref(false)
+const { result, loading, called } = useQuery(GET_USERS, undefined, { enabled })
+
+// Skeleton only on the very first fetch, not on later refetches
+const showSkeleton = computed(() => loading.value && !called.value)
+
+// Empty state only after the query has actually run
+const showEmpty = computed(() => called.value && !loading.value && !result.value)
+
+// Trigger the first fetch
+enabled.value = true
+```
+
+`called` stays `false` until the query truly starts, so `enabled: false` queries report `called === false` until enabled.
 
 ## Related
 - [`useLazyQuery`](/composables/useLazyQuery)

--- a/packages/web/src/App.vue
+++ b/packages/web/src/App.vue
@@ -19,7 +19,7 @@ const vars = reactive<PostsQueryVariables>({
     userId: 1
 })
 
-const { error, result } = useQuery(PostsDocument, vars, {
+const { called, error, result } = useQuery(PostsDocument, vars, {
     enabled,
     fetchPolicy: 'cache-first',
     keepPreviousResult: true,
@@ -120,7 +120,7 @@ function handleUpdate() {
           <button type="button" class="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-slate-800 hover:bg-slate-700 active:bg-slate-800 text-gray-200 border border-white/10 transition-colors" @click="enabled = !enabled">
             {{ enabled ? 'Disable' : 'Enable' }} Query
           </button>
-          <span class="ml-auto text-xs text-gray-400">Query Status: <strong class="text-gray-200">{{ enabled ? 'Enabled' : 'Disabled' }}</strong></span>
+          <span class="ml-auto text-xs text-gray-400">Query Status: <strong class="text-gray-200">{{ enabled ? 'Enabled' : 'Disabled' }}</strong> • Called: <strong class="text-gray-200">{{ called ? 'Yes' : 'No' }}</strong></span>
         </div>
 
         <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">

--- a/skills/vue3-apollo/SKILL.md
+++ b/skills/vue3-apollo/SKILL.md
@@ -75,7 +75,7 @@ Read these files based on task type:
 4. Nuxt auth is cookie-based in current runtime creation flow.
 5. Nuxt `useAsyncQuery` uses object options and integrates with `useAsyncData`.
 6. Nuxt runtime provides `apollo:error` hook payload for centralized handling.
-7. `useLazyQuery` is built on top of `useQuery`, exposes `called` and `execute()`, and `execute()` follows Apollo cache policy.
+7. `useLazyQuery` is built on top of `useQuery` and adds `execute()` (which follows Apollo cache policy); both composables share the same sticky `called` flag exposed by `useQuery`.
 8. Nuxt module `apollo.autoImports` is enabled by default; if disabled, import composables manually.
 
 ## Implementation Checklist

--- a/skills/vue3-apollo/references/composables-use-lazy-query.md
+++ b/skills/vue3-apollo/references/composables-use-lazy-query.md
@@ -26,7 +26,7 @@ Notes:
 ## Returns
 
 1. All `useQuery` return fields (`result`, `loading`, `error`, `networkStatus`, `refetch`, `fetchMore`, `query`, `start`, `stop`, `onResult`, `onError`).
-2. `called: Ref<boolean>` (`false` until first `execute()`).
+2. `called: Ref<boolean>` (`false` until first `execute()`); this is the same sticky flag exposed by `useQuery`.
 3. `execute(variables?) => Promise<TData>`.
 
 ## Execution flow

--- a/skills/vue3-apollo/references/composables-use-query.md
+++ b/skills/vue3-apollo/references/composables-use-query.md
@@ -37,12 +37,14 @@ import { gql } from 'graphql-tag'
 9. `stop()`
 10. `onResult((data, context) => {})`
 11. `onError((error, context) => {})`
+12. `called` (`Ref<boolean>`; sticky, `true` once the query first starts fetching)
 
 Return behavior note:
 
 1. `refetch()` and `fetchMore()` may return `undefined` when query is disabled or not started.
 2. Treat manual operations as conditional calls, not always-guaranteed network requests.
 3. `query.value` can be `undefined` before observer starts or when query is stopped.
+4. `called` starts `false`, flips to `true` on first fetch (SSR prefetch or client observer), and stays `true` across `stop()`/`start()`. With `enabled: false` it stays `false` until the query actually runs. Use it to tell "never fetched yet" from "fetched at least once" (e.g. first-load placeholder vs empty state).
 
 ## Key options
 


### PR DESCRIPTION
Expose a sticky `called` ref from `useQuery` that turns true the first
time the query starts fetching (SSR prefetch or client observer) and stays
true across stop()/start() cycles. This lets the UI distinguish "never
fetched yet" from "fetched at least once" (e.g. first-load placeholder vs
empty state). Naming mirrors the existing `called` in useLazyQuery.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0132kfukTiZLgwNygq1erYzN