### PR TITLE
fix(core): align useMutation throws/onError/onDone behavior with docs

### DIFF
--- a/.changeset/fix-usemutation-error-handling.md
+++ b/.changeset/fix-usemutation-error-handling.md
@@ -1,0 +1,12 @@
+---
+"@vue3-apollo/core": major
+---
+
+Align `useMutation` error/result handling with its documented behavior.
+
+- **BREAKING:** `throws: 'auto'` (the default) now mirrors Apollo's default behavior — a failed `mutate()` rethrows unless an error policy other than `'none'` is in effect (resolved from per-call options, base options, then the client's default mutate options). Previously every error was swallowed unless `throws: 'always'` was set. Callers that relied on the old swallow-by-default behavior should switch to `throws: 'never'` or wrap `mutate()` in `try/catch`.
+- `onDone` now only fires when the mutation returns defined data, matching the documentation and `useQuery`.
+- `onError` now awaits `nextTick()` in the `result.error` branch so its timing is consistent with the `catch` path.
+- The Apollo mutate options are now derived once instead of on every `mutate()` call.
+
+`mutate()` continues to resolve to `undefined` when the mutation errors and `throws` is not `'always'` (the error is exposed via the `error` ref and the `onError` hook).

--- a/packages/core/src/composables/useMutation.ts
+++ b/packages/core/src/composables/useMutation.ts
@@ -8,6 +8,7 @@ import { nextTick, ref, shallowRef, toValue } from 'vue'
 import type { HookContext, UseBaseOption } from '../utils/type'
 
 import { useApolloTracking } from '../helpers/useApolloTracking'
+import { isDefined } from '../utils/isDefined'
 import { omit } from '../utils/omit'
 import { useApolloClient } from './useApolloClient'
 
@@ -27,7 +28,9 @@ export type UseMutationOptions<
     /**
      * Controls when the mutation should throw errors.
      * - 'always': Always throw errors (useful with try/catch)
-     * - 'auto': Default Apollo behavior
+     * - 'auto': Mirror Apollo's default behavior — throw unless an error policy
+     *   other than 'none' is in effect (in which case errors are surfaced via
+     *   the `error` ref instead of rejecting)
      * - 'never': Never throw, only set error state
      *
      * @default 'auto'
@@ -110,19 +113,42 @@ export function useMutation<
     const onDone = createEventHook<[TData, HookContext]>()
     const onError = createEventHook<[ErrorLike, HookContext]>()
 
-    const getMutationBaseOptions = () => {
-        if (!options) {
-            return {}
-        }
-
-        return omit(options, ['throws', 'clientId', 'loadingKey'])
-    }
+    // The custom options are static, so the Apollo-only options can be derived once.
+    const mutationBaseOptions = options
+        ? omit(options, ['throws', 'clientId', 'loadingKey'])
+        : {}
 
     useApolloTracking({
         id: options?.loadingKey,
         state: loading,
         type: 'mutations'
     })
+
+    /**
+     * Decide whether a caught error should be re-thrown, based on the `throws`
+     * option:
+     * - 'always': always throw
+     * - 'never': never throw, only set the error state
+     * - 'auto' (default): mirror Apollo's default behavior — throw unless an
+     *   error policy other than 'none' is in effect (in which case GraphQL
+     *   errors are surfaced via `result.error` instead of rejecting).
+     */
+    const shouldThrowOnError = (
+        mutateOptions?: Omit<ApolloClient.MutateOptions<TData, TVariables, TCache>, 'mutation' | 'variables'>
+    ) => {
+        if (options?.throws === 'always') {
+            return true
+        }
+        if (options?.throws === 'never') {
+            return false
+        }
+
+        const errorPolicy = mutateOptions?.errorPolicy
+            ?? options?.errorPolicy
+            ?? client.defaultOptions?.mutate?.errorPolicy
+
+        return errorPolicy == null || errorPolicy === 'none'
+    }
 
     const mutate = async (
         variables?: TVariables,
@@ -136,18 +162,22 @@ export function useMutation<
             const result = await client.mutate<TData, TVariables, TCache>({
                 mutation: toValue(document),
                 variables: variables as TVariables ?? undefined,
-                ...getMutationBaseOptions(),
+                ...mutationBaseOptions,
                 ...mutateOptions
             })
 
             if (result.error) {
                 error.value = result.error
+                await nextTick()
                 void onError.trigger(result.error, { client })
             }
             else {
                 data.value = result.data
                 await nextTick()
-                void onDone.trigger(result.data as TData, { client })
+                // Only fire onDone when actual data was returned, mirroring useQuery.
+                if (isDefined(result.data)) {
+                    void onDone.trigger(result.data as TData, { client })
+                }
             }
 
             return result
@@ -158,7 +188,7 @@ export function useMutation<
 
             await nextTick()
             void onError.trigger(mutationErrorValue, { client })
-            if (options?.throws === 'always') {
+            if (shouldThrowOnError(mutateOptions)) {
                 throw e
             }
         }
@@ -204,7 +234,9 @@ export function useMutation<
          *
          * @param variables - Variables for the mutation
          * @param mutateOptions - Per-call options that override base options
-         * @returns Promise resolving to the mutation result
+         * @returns Promise resolving to the mutation result, or `undefined` when
+         * the mutation errors and `throws` is not `'always'` (the error is
+         * surfaced via the `error` ref and the `onError` hook instead).
          *
          * @example
          * ```ts

--- a/packages/docs/composables/useMutation.md
+++ b/packages/docs/composables/useMutation.md
@@ -88,8 +88,15 @@ function useMutation<TData, TVariables, TCache>(
 - `clientId?: string` to target a named client.
 
 ## Notes
-- `throws: 'always'` rethrows caught mutation exceptions after emitting `onError`.
-- Other `throws` values keep errors in reactive state/hooks.
+- `throws` controls when `mutate()` rethrows after emitting `onError`:
+  - `'always'`: always rethrow caught mutation exceptions.
+  - `'auto'` (default): mirror Apollo's default behavior — rethrow unless an
+    error policy other than `'none'` is in effect (then errors are surfaced via
+    the `error` ref instead of rejecting).
+  - `'never'`: never rethrow, only keep errors in reactive state/hooks.
+- When the mutation errors and `throws` is not `'always'`, `mutate()` resolves to
+  `undefined` (the error is exposed through the `error` ref and `onError`).
+- `onDone` only fires when the mutation returns defined data.
 - Per-call `mutateOptions` overrides base options provided to `useMutation`.
 
 ## Examples

--- a/skills/vue3-apollo/references/composables-use-mutation.md
+++ b/skills/vue3-apollo/references/composables-use-mutation.md
@@ -48,8 +48,15 @@ Return behavior note:
 
 `throws` behavior in current implementation:
 
-1. `throws: 'always'` re-throws only in the `catch` path.
-2. If Apollo returns `result.error` without throwing, error is stored and `onError` fires, but no throw is forced by composable.
+1. `throws: 'always'` re-throws caught mutation exceptions (in the `catch` path).
+2. `throws: 'auto'` (default) re-throws caught exceptions unless an error policy
+   other than `'none'` is in effect (resolved from per-call options, base
+   options, then the client's default mutate options). This mirrors Apollo's
+   default behavior.
+3. `throws: 'never'` never re-throws; the error is only stored in `error` and
+   emitted via `onError`.
+4. If Apollo returns `result.error` without throwing (e.g. `errorPolicy: 'all'`),
+   the error is stored and `onError` fires, but no throw is forced.
 
 ## Basic usage
 


### PR DESCRIPTION
- Implement the full `throws` contract: `'auto'` (default) now mirrors
  Apollo's default behavior — rethrowing on error unless an error policy
  other than 'none' is in effect — making `'auto'` and `'never'` distinct.
  Previously every error was swallowed unless `throws: 'always'`.
- Only fire `onDone` when the mutation returns defined data, matching the
  documented behavior and useQuery.
- Await `nextTick()` before firing `onError` in the `result.error` branch so
  error-hook timing is consistent with the catch path.
- Compute the Apollo-only base options once instead of on every `mutate()`.
- Document that `mutate()` resolves to `undefined` on a swallowed error.
- Update docs and skill reference to reflect the throws semantics.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GYEdsfVvbRzZDrj8U1gPDm