### PR TITLE
fix(core): make useSubscription start() idempotent and fix SSR loading

### DIFF
--- a/.changeset/fix-usesubscription-start-idempotent.md
+++ b/.changeset/fix-usesubscription-start-idempotent.md
@@ -1,0 +1,8 @@
+---
+"@vue3-apollo/core": patch
+---
+
+Fix `useSubscription` lifecycle handling:
+
+- Make `start()` idempotent so calling it while a subscription is already running is a safe no-op, instead of overwriting `subscription` with a new (never-subscribed) observable while the previous observer keeps running. This was reachable via the documented "enabled gate + manual control" usage (`enabled.value = true; start()`), where both the `enabled` watcher and the manual call would invoke `start()`.
+- Initialize `loading` to `false` during SSR, since subscriptions are client-only and never connect on the server — avoiding a connecting state that can never resolve in the server-rendered output.

--- a/packages/core/src/composables/useSubscription.ts
+++ b/packages/core/src/composables/useSubscription.ts
@@ -73,7 +73,10 @@ export function useSubscription<
     const enabled = computed(() => toValue(options?.enabled ?? true))
 
     const data = shallowRef<TData>()
-    const loading = ref(enabled.value)
+    // Subscriptions never run during SSR, so there is nothing "connecting" on the
+    // server — start in a non-loading state there to avoid a spinner that can
+    // never resolve in the server-rendered output.
+    const loading = ref(!isServer() && enabled.value)
     const error = ref<ErrorLike>()
 
     const subscriptionData = createEventHook<[TData, HookContext]>()
@@ -151,7 +154,12 @@ export function useSubscription<
     }
 
     const start = () => {
-        if (!enabled.value) {
+        // Bail out when disabled, or when a subscription is already running, so
+        // start() is idempotent and never orphans a previous observable. Without
+        // the subscription.value guard a second start() would overwrite
+        // subscription.value with a new (never-subscribed) observable while the
+        // previous observer kept running — leaving inconsistent state.
+        if (!enabled.value || subscription.value) {
             return
         }
 


### PR DESCRIPTION
- Guard start() on subscription.value so calling it while a subscription
  is already running is a safe no-op, instead of overwriting subscription
  with a new (never-subscribed) observable while the previous observer
  keeps running. This was reachable via the documented "enabled gate +
  manual control" usage (enabled.value = true; start()), where both the
  enabled watcher and the manual call invoke start().
- Initialize loading to false during SSR, since subscriptions are
  client-only and never connect on the server, avoiding a connecting
  state that can never resolve in server-rendered output.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017euYCP2HUyE6jKLmMXaQ1V