### PR TITLE
fix(core): overhaul loading-state management

### DIFF
--- a/.changeset/fix-loading-state-tracking.md
+++ b/.changeset/fix-loading-state-tracking.md
@@ -1,0 +1,11 @@
+---
+"@vue3-apollo/core": minor
+---
+
+Overhaul core loading-state management:
+
+- Prune empty owner buckets in the tracking store so `activeByOwner` no longer grows unbounded (one stale `{}` per mounted component/key) over the lifetime of a long-running app.
+- Replace the per-track `{ ...map }` spread (O(owners) allocation on every operation) with `triggerRef`, and skip reactivity entirely for no-op decrements (e.g. the `immediate` watch firing with an initial `false`).
+- Count in-flight calls in `useMutation` (and overlapping `refetch`/`fetchMore`/variable updates in `useQuery`) so concurrent operations no longer clear `loading` while another is still running.
+- Namespace owner ids so a custom `loadingKey` can never collide with a component `uid`.
+- Add `useGlobalLoading()` for app-wide loading state (`{ any, queries, mutations, subscriptions }`), and align return-type annotations across the owner-scoped loading helpers.

--- a/packages/core/src/composables/useMutation.ts
+++ b/packages/core/src/composables/useMutation.ts
@@ -3,7 +3,7 @@ import type { DocumentNode } from 'graphql'
 import type { MaybeRefOrGetter } from 'vue'
 
 import { createEventHook } from '@vueuse/core'
-import { nextTick, ref, shallowRef, toValue } from 'vue'
+import { computed, nextTick, ref, shallowRef, toValue } from 'vue'
 
 import type { HookContext, UseBaseOption } from '../utils/type'
 
@@ -106,7 +106,10 @@ export function useMutation<
     const client = useApolloClient(options?.clientId)
 
     const data = shallowRef<TData>()
-    const loading = ref(false)
+    // Count in-flight calls instead of a single boolean so overlapping
+    // `mutate()` calls don't clear `loading` while another is still running.
+    const pending = ref(0)
+    const loading = computed(() => pending.value > 0)
     const error = ref<ErrorLike>()
     const called = ref(false)
 
@@ -154,7 +157,7 @@ export function useMutation<
         variables?: TVariables,
         mutateOptions?: Omit<ApolloClient.MutateOptions<TData, TVariables, TCache>, 'mutation' | 'variables'>
     ) => {
-        loading.value = true
+        pending.value++
         error.value = undefined
         called.value = true
 
@@ -193,13 +196,13 @@ export function useMutation<
             }
         }
         finally {
-            loading.value = false
+            pending.value = Math.max(0, pending.value - 1)
         }
     }
 
     const reset = () => {
         data.value = undefined
-        loading.value = false
+        pending.value = 0
         error.value = undefined
         called.value = false
     }

--- a/packages/core/src/composables/useQuery.ts
+++ b/packages/core/src/composables/useQuery.ts
@@ -176,6 +176,19 @@ export function useQuery<TData = unknown, TVariables extends OperationVariables 
     // apart from "fetched at least once".
     const called = ref(false)
 
+    // Number of in-flight manual operations (refetch / fetchMore / variable
+    // updates). Used so overlapping calls don't clear `loading` while another is
+    // still running.
+    const manualPending = ref(0)
+
+    // Clear the loading flag only once every manual operation has settled.
+    const settleManual = () => {
+        manualPending.value = Math.max(0, manualPending.value - 1)
+        if (manualPending.value === 0) {
+            loading.value = false
+        }
+    }
+
     const onResultEvent = createEventHook<[TData, HookContext]>()
     const onErrorEvent = createEventHook<[ErrorLike, HookContext]>()
 
@@ -277,6 +290,7 @@ export function useQuery<TData = unknown, TVariables extends OperationVariables 
 
     const stop = () => {
         loading.value = false
+        manualPending.value = 0
         networkStatus.value = undefined
 
         if (observer.value && !observer.value.closed) {
@@ -349,10 +363,12 @@ export function useQuery<TData = unknown, TVariables extends OperationVariables 
             }
 
             error.value = undefined
+            manualPending.value++
             loading.value = true
-            // Errors surface through the observer's error handler, which resets
-            // loading; catch the rejection here only to avoid an unhandled promise.
-            void query.value.setVariables(newVariables).catch(() => {})
+            // Errors surface through the observer's error handler; catch the
+            // rejection here only to avoid an unhandled promise. `settleManual`
+            // keeps `loading` true until every overlapping manual op resolves.
+            void query.value.setVariables(newVariables).catch(() => {}).finally(settleManual)
         }
 
         // Debounce has priority over throttle if both are provided
@@ -382,13 +398,15 @@ export function useQuery<TData = unknown, TVariables extends OperationVariables 
             return
         }
         error.value = undefined
+        manualPending.value++
         loading.value = true
         try {
             return await query.value.refetch(variables)
         }
         finally {
-            // Ensure loading is cleared even if the refetch rejects.
-            loading.value = false
+            // Ensure loading is cleared even if the refetch rejects, but not
+            // while another overlapping manual op is still running.
+            settleManual()
         }
     }
 
@@ -398,13 +416,15 @@ export function useQuery<TData = unknown, TVariables extends OperationVariables 
         }
 
         error.value = undefined
+        manualPending.value++
         loading.value = true
         try {
             return await query.value.fetchMore(options)
         }
         finally {
-            // Ensure loading is cleared even if fetchMore rejects.
-            loading.value = false
+            // Ensure loading is cleared even if fetchMore rejects, but not while
+            // another overlapping manual op is still running.
+            settleManual()
         }
     }
 

--- a/packages/core/src/helpers/useApolloTracker.ts
+++ b/packages/core/src/helpers/useApolloTracker.ts
@@ -1,5 +1,5 @@
 import { createGlobalState } from '@vueuse/core'
-import { shallowRef } from 'vue'
+import { shallowRef, triggerRef } from 'vue'
 
 export type ApolloOperationType = 'mutations' | 'queries' | 'subscriptions'
 
@@ -37,24 +37,53 @@ export const useApolloTrackingStore = createGlobalState(
         const track = ({ id, state, type }: TrackParams) => {
             const delta = state ? 1 : -1
 
-            // Update global counters
-            activeGlobal.value[type] = Math.max(0, (activeGlobal.value[type] || 0) + delta)
+            let ownerCounters = activeByOwner.value[id]
+
+            // A decrement for an owner we are not tracking is a no-op (e.g. an
+            // `immediate` watch firing with an initial `false`, or a second
+            // dispose after the counter already reached zero). Bail out without
+            // creating an empty bucket and without triggering reactivity —
+            // global counters are only ever incremented alongside an owner, so
+            // there is nothing to decrement globally either.
+            if (!ownerCounters && delta < 0) {
+                return
+            }
+
+            if (!ownerCounters) {
+                ownerCounters = activeByOwner.value[id] = {}
+            }
 
             // Update by-owner counters
-            if (!activeByOwner.value[id]) {
-                activeByOwner.value[id] = {}
-            }
-
-            const ownerCounters = activeByOwner.value[id]
-            ownerCounters[type] = Math.max(0, (ownerCounters[type] || 0) + delta)
-
-            if (ownerCounters[type] === 0) {
+            const nextOwner = Math.max(0, (ownerCounters[type] || 0) + delta)
+            if (nextOwner === 0) {
                 delete ownerCounters[type]
             }
+            else {
+                ownerCounters[type] = nextOwner
+            }
 
-            // Trigger reactivity
-            activeGlobal.value = { ...activeGlobal.value }
-            activeByOwner.value = { ...activeByOwner.value }
+            // Prune empty owners so `activeByOwner` does not grow unbounded as
+            // components/composables (each with a distinct uid or key) mount and
+            // unmount over the lifetime of a long-running app.
+            if (Object.keys(ownerCounters).length === 0) {
+                delete activeByOwner.value[id]
+            }
+
+            // Update global counters
+            const nextGlobal = Math.max(0, (activeGlobal.value[type] || 0) + delta)
+            if (nextGlobal === 0) {
+                delete activeGlobal.value[type]
+            }
+            else {
+                activeGlobal.value[type] = nextGlobal
+            }
+
+            // The `shallowRef`s keep the same underlying object reference;
+            // `triggerRef` notifies readers without allocating a fresh copy of
+            // the whole map on every operation (the previous `{ ...map }` spread
+            // was O(owners) per track).
+            triggerRef(activeByOwner)
+            triggerRef(activeGlobal)
         }
 
         return {

--- a/packages/core/src/helpers/useApolloTracking.ts
+++ b/packages/core/src/helpers/useApolloTracking.ts
@@ -5,6 +5,7 @@ import { getCurrentInstance, getCurrentScope, onScopeDispose, watch } from 'vue'
 import type { ApolloOperationType } from './useApolloTracker'
 
 import { isServer } from '../utils/isServer'
+import { customOwnerId, instanceOwnerId } from '../utils/ownerId'
 import { useApolloTrackingStore } from './useApolloTracker'
 
 interface UseApolloTrackingOptions {
@@ -14,13 +15,27 @@ interface UseApolloTrackingOptions {
 }
 
 export function useApolloTracking({ id: customId, state, type }: UseApolloTrackingOptions) {
-    // Setup loading tracking
+    // Setup loading tracking.
+    //
+    // Tracking is skipped on the server: the store is created via
+    // `createGlobalState`, so it is a process-wide singleton. Writing to it
+    // during SSR would let concurrent requests share (and leak) loading state
+    // across each other. Safely tracking SSR loading would require per-request
+    // scoped state, which is out of scope here.
     const currentScope = getCurrentScope()
     if (currentScope && !isServer()) {
         const { track } = useApolloTrackingStore()
         const currentInstance = getCurrentInstance()
 
-        const id = customId ?? currentInstance?.uid ?? Math.random().toString(36).slice(2)
+        // Namespace the bucket so custom keys can never collide with component
+        // uids (see `utils/ownerId`). The random fallback keeps the global
+        // counters correct when there is no owner to read it back; the prune in
+        // the store means it no longer leaks.
+        const id = customId != null
+            ? customOwnerId(customId)
+            : currentInstance
+                ? instanceOwnerId(currentInstance.uid)
+                : Math.random().toString(36).slice(2)
 
         watch(state, (state) => {
             track({

--- a/packages/core/src/helpers/useGlobalLoading.ts
+++ b/packages/core/src/helpers/useGlobalLoading.ts
@@ -1,0 +1,65 @@
+import type { ComputedRef } from 'vue'
+
+import { computed } from 'vue'
+
+import { useApolloTrackingStore } from './useApolloTracker'
+
+/**
+ * Global loading state aggregated across every owner.
+ */
+export interface GlobalLoadingState {
+    /**
+     * Whether any query, mutation, or subscription is currently loading.
+     */
+    any: boolean
+    /**
+     * Whether any mutation is currently loading.
+     */
+    mutations: boolean
+    /**
+     * Whether any query is currently loading.
+     */
+    queries: boolean
+    /**
+     * Whether any subscription is currently loading.
+     */
+    subscriptions: boolean
+}
+
+/**
+ * Track the global Apollo loading state across all components and composables.
+ *
+ * Unlike the owner-scoped helpers (`useQueriesLoading`, ...), this reads the
+ * global counters, so it reflects activity from the entire app — handy for a
+ * top-level progress bar or loading overlay.
+ *
+ * @returns A computed ref with per-type booleans plus an `any` aggregate
+ *
+ * @example
+ * ```TypeScript
+ * const loading = useGlobalLoading()
+ *
+ * // Top-level spinner while anything is in flight
+ * const showSpinner = computed(() => loading.value.any)
+ *
+ * // Or only while queries are loading
+ * const showQuerySpinner = computed(() => loading.value.queries)
+ * ```
+ */
+export function useGlobalLoading(): ComputedRef<GlobalLoadingState> {
+    const { activeGlobal } = useApolloTrackingStore()
+
+    return computed(() => {
+        const counters = activeGlobal.value
+        const queries = (counters.queries || 0) > 0
+        const mutations = (counters.mutations || 0) > 0
+        const subscriptions = (counters.subscriptions || 0) > 0
+
+        return {
+            any: queries || mutations || subscriptions,
+            mutations,
+            queries,
+            subscriptions
+        }
+    })
+}

--- a/packages/core/src/helpers/useMutationsLoading.ts
+++ b/packages/core/src/helpers/useMutationsLoading.ts
@@ -1,6 +1,6 @@
-import { computed, getCurrentInstance } from 'vue'
+import type { ComputedRef } from 'vue'
 
-import { useApolloTrackingStore } from './useApolloTracker'
+import { useOperationLoading } from './useOperationLoading'
 
 /**
  * Track the loading state for Apollo mutations in a specific component or scope
@@ -17,22 +17,6 @@ import { useApolloTrackingStore } from './useApolloTracker'
  * const isLoading = useMutationsLoading('my-custom-id')
  * ```
  */
-export function useMutationsLoading(id?: number | string) {
-    const { activeByOwner } = useApolloTrackingStore()
-
-    const loadingId = id ?? getCurrentInstance()?.uid
-
-    return computed(() => {
-        if (!loadingId) {
-            return false
-        }
-
-        const ownerCounters = activeByOwner.value[loadingId]
-
-        if (!ownerCounters) {
-            return false
-        }
-
-        return (ownerCounters.mutations || 0) > 0
-    })
+export function useMutationsLoading(id?: number | string): ComputedRef<boolean> {
+    return useOperationLoading('mutations', id)
 }

--- a/packages/core/src/helpers/useOperationLoading.ts
+++ b/packages/core/src/helpers/useOperationLoading.ts
@@ -1,0 +1,39 @@
+import type { ComputedRef } from 'vue'
+
+import { computed, getCurrentInstance } from 'vue'
+
+import type { ApolloOperationType } from './useApolloTracker'
+
+import { customOwnerId, instanceOwnerId } from '../utils/ownerId'
+import { useApolloTrackingStore } from './useApolloTracker'
+
+/**
+ * Shared implementation behind `useQueriesLoading`, `useMutationsLoading` and
+ * `useSubscriptionsLoading`.
+ *
+ * Resolves the owner bucket the same way as `useApolloTracking` (explicit id ->
+ * custom key, otherwise the current component uid) so readers and writers
+ * always agree on the namespaced id.
+ *
+ * @param type - Operation type to observe
+ * @param id - Optional owner id. Falls back to the current component uid.
+ * @returns A computed ref indicating whether any matching operation is loading
+ */
+export function useOperationLoading(type: ApolloOperationType, id?: number | string): ComputedRef<boolean> {
+    const { activeByOwner } = useApolloTrackingStore()
+
+    const instanceUid = getCurrentInstance()?.uid
+    const ownerId = id != null
+        ? customOwnerId(id)
+        : instanceUid != null
+            ? instanceOwnerId(instanceUid)
+            : undefined
+
+    return computed(() => {
+        if (ownerId == null) {
+            return false
+        }
+
+        return (activeByOwner.value[ownerId]?.[type] || 0) > 0
+    })
+}

--- a/packages/core/src/helpers/useQueriesLoading.ts
+++ b/packages/core/src/helpers/useQueriesLoading.ts
@@ -1,8 +1,6 @@
 import type { ComputedRef } from 'vue'
 
-import { computed, getCurrentInstance } from 'vue'
-
-import { useApolloTrackingStore } from './useApolloTracker'
+import { useOperationLoading } from './useOperationLoading'
 
 /**
  * Track the loading state for Apollo queries in a specific component or scope
@@ -13,28 +11,12 @@ import { useApolloTrackingStore } from './useApolloTracker'
  * @example
  * ```TypeScript
  * // In a component - automatically tracks this component's queries
- * const isLoading = useQueryLoading()
+ * const isLoading = useQueriesLoading()
  *
  * // Track queries with a custom id
- * const isLoading = useQueryLoading('my-custom-id')
+ * const isLoading = useQueriesLoading('my-custom-id')
  * ```
  */
 export function useQueriesLoading(id?: number | string): ComputedRef<boolean> {
-    const { activeByOwner } = useApolloTrackingStore()
-
-    const loadingId = id ?? getCurrentInstance()?.uid
-
-    return computed(() => {
-        if (!loadingId) {
-            return false
-        }
-
-        const ownerCounters = activeByOwner.value[loadingId]
-
-        if (!ownerCounters) {
-            return false
-        }
-
-        return (ownerCounters.queries || 0) > 0
-    })
+    return useOperationLoading('queries', id)
 }

--- a/packages/core/src/helpers/useSubscriptionsLoading.ts
+++ b/packages/core/src/helpers/useSubscriptionsLoading.ts
@@ -1,6 +1,6 @@
-import { computed, getCurrentInstance } from 'vue'
+import type { ComputedRef } from 'vue'
 
-import { useApolloTrackingStore } from './useApolloTracker'
+import { useOperationLoading } from './useOperationLoading'
 
 /**
  * Track the loading state for Apollo subscriptions in a specific component or scope
@@ -17,22 +17,6 @@ import { useApolloTrackingStore } from './useApolloTracker'
  * const isLoading = useSubscriptionsLoading('my-custom-id')
  * ```
  */
-export function useSubscriptionsLoading(id?: number | string) {
-    const { activeByOwner } = useApolloTrackingStore()
-
-    const loadingId = id ?? getCurrentInstance()?.uid
-
-    return computed(() => {
-        if (!loadingId) {
-            return false
-        }
-
-        const ownerCounters = activeByOwner.value[loadingId]
-
-        if (!ownerCounters) {
-            return false
-        }
-
-        return (ownerCounters.subscriptions || 0) > 0
-    })
+export function useSubscriptionsLoading(id?: number | string): ComputedRef<boolean> {
+    return useOperationLoading('subscriptions', id)
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,7 +11,9 @@ export * from './constants/apollo'
 
 export * from './helpers/useApolloTracker'
 export * from './helpers/useApolloTracking'
+export * from './helpers/useGlobalLoading'
 export * from './helpers/useMutationsLoading'
+export * from './helpers/useOperationLoading'
 export * from './helpers/useQueriesLoading'
 export * from './helpers/useSubscriptionsLoading'
 

--- a/packages/core/src/utils/ownerId.ts
+++ b/packages/core/src/utils/ownerId.ts
@@ -1,0 +1,25 @@
+/**
+ * Owner-id namespacing for the Apollo tracking store.
+ *
+ * Custom loading keys and component instance uids share the same
+ * `number | string` space, so a custom `loadingKey: 5` could previously collide
+ * with the component whose `uid` is `5` and merge their unrelated loading state.
+ * Prefixing each source keeps the two buckets distinct while staying consistent
+ * between the writer (`useApolloTracking`) and the readers
+ * (`useQueriesLoading` / `useMutationsLoading` / `useSubscriptionsLoading`).
+ */
+
+/**
+ * Bucket id for an explicit/custom loading key (`loadingKey`, or the `id`
+ * passed to the loading helpers).
+ */
+export function customOwnerId(id: number | string): string {
+    return `key:${id}`
+}
+
+/**
+ * Bucket id derived from a component instance uid.
+ */
+export function instanceOwnerId(uid: number): string {
+    return `uid:${uid}`
+}

--- a/packages/docs/advance/tracking.md
+++ b/packages/docs/advance/tracking.md
@@ -33,6 +33,7 @@ const isBusy = useQueriesLoading()
 |---|---|---|
 | `useApolloTrackingStore` | Global counters + per-owner map + manual `track` | `const { activeGlobal, activeByOwner, track } = useApolloTrackingStore()` |
 | `useApolloTracking` | Forward a `Ref<boolean>` into tracker counters | `useApolloTracking({ id?, state, type })` |
+| `useGlobalLoading` | App-wide activity across all owners | `useGlobalLoading() => ComputedRef<GlobalLoadingState>` |
 | `useMutationsLoading` | Owner-scoped mutation activity | `useMutationsLoading(id?) => ComputedRef<boolean>` |
 | `useQueriesLoading` | Owner-scoped query activity | `useQueriesLoading(id?) => ComputedRef<boolean>` |
 | `useSubscriptionsLoading` | Owner-scoped subscription activity | `useSubscriptionsLoading(id?) => ComputedRef<boolean>` |
@@ -45,19 +46,23 @@ const isBusy = useQueriesLoading()
 - `useApolloTracker` remains as a deprecated alias of `useApolloTrackingStore`.
 
 ## Notes
-- `useApolloTracking` is a no-op on the server.
-- `useApolloTracking` requires an active Vue scope to auto-clean counters on dispose.
+- `useApolloTracking` is a no-op on the server. The store is a process-wide singleton (`createGlobalState`), so tracking during SSR would leak loading state across concurrent requests.
+- `useApolloTracking` requires an active Vue scope to auto-clean counters on dispose. Owner buckets are pruned once their counters reach zero, so the per-owner map stays bounded across mount/unmount cycles.
 - Owner-scoped helpers without a component instance and without explicit `id` resolve to `false`.
+- Owner ids are namespaced internally: an explicit `id`/`loadingKey` is bucketed separately from component uids, so a numeric `loadingKey` can never collide with a component whose `uid` happens to match. `useQuery({ loadingKey })` and `useQueriesLoading(loadingKey)` always resolve to the same bucket.
 
 ## Examples
 
 ```ts
 import { computed } from 'vue'
-import { useApolloTrackingStore } from '@vue3-apollo/core'
+import { useGlobalLoading } from '@vue3-apollo/core'
 
-const { activeGlobal } = useApolloTrackingStore()
+const loading = useGlobalLoading()
 
-const isAnyQueryLoading = computed(() => (activeGlobal.value.queries ?? 0) > 0)
+// App-wide spinner while anything is in flight
+const isBusy = computed(() => loading.value.any)
+// Or only while queries are loading
+const isAnyQueryLoading = computed(() => loading.value.queries)
 ```
 
 ```ts

--- a/skills/vue3-apollo/references/tracking-and-loading.md
+++ b/skills/vue3-apollo/references/tracking-and-loading.md
@@ -14,10 +14,12 @@ Use tracking helpers when UI needs loading visibility across GraphQL operations:
 - global store with `activeGlobal`, `activeByOwner`, and `track()`.
 2. `useApolloTracking({ id?, state, type })`:
 - auto-track a `Ref<boolean>` into store counters.
-3. `useQueriesLoading(id?)`
-4. `useMutationsLoading(id?)`
-5. `useSubscriptionsLoading(id?)`
-6. Deprecated alias: `useApolloTracker` -> same as `useApolloTrackingStore`.
+3. `useGlobalLoading()`:
+- app-wide `ComputedRef<{ any, queries, mutations, subscriptions }>` across all owners.
+4. `useQueriesLoading(id?)`
+5. `useMutationsLoading(id?)`
+6. `useSubscriptionsLoading(id?)`
+7. Deprecated alias: `useApolloTracker` -> same as `useApolloTrackingStore`.
 
 ## Core model
 
@@ -28,8 +30,25 @@ Use tracking helpers when UI needs loading visibility across GraphQL operations:
 3. Store clamps counters at `0` to avoid negative values.
 4. `useApolloTracking` only runs on client and inside active scope.
 5. `useQuery({ loadingKey })` uses `loadingKey` as owner id for query counters.
+6. Owner ids are namespaced internally: an explicit `id`/`loadingKey` and a component `uid` live in separate buckets, so a numeric `loadingKey` can never collide with a component whose `uid` matches. `useQuery({ loadingKey })` and `useXxxLoading(loadingKey)` still resolve to the same bucket.
+7. Owner buckets are pruned once their counters reach `0`, so `activeByOwner` stays bounded across mount/unmount cycles (no leftover empty entries).
+8. `loading` from `useQuery`/`useMutation` counts in-flight calls, so overlapping `mutate()`/`refetch()`/`fetchMore()` stay `true` until the last one settles.
 
 ## Quick setup
+
+Prefer `useGlobalLoading()` for app-wide indicators:
+
+```ts
+import { computed } from 'vue'
+import { useGlobalLoading } from '@vue3-apollo/core'
+
+const loading = useGlobalLoading()
+
+const isAnythingLoading = computed(() => loading.value.any)
+// Per-type: loading.value.queries / .mutations / .subscriptions
+```
+
+Reading raw counters from the store stays available for advanced cases:
 
 ```ts
 import { computed } from 'vue'
@@ -103,14 +122,9 @@ const isCheckoutBusy = useQueriesLoading(ownerId)
 Goal: show one loading overlay for all operations.
 
 ```ts
-const { activeGlobal } = useApolloTrackingStore()
+const loading = useGlobalLoading()
 
-const showOverlay = computed(() => {
-  const q = activeGlobal.value.queries ?? 0
-  const m = activeGlobal.value.mutations ?? 0
-  const s = activeGlobal.value.subscriptions ?? 0
-  return q + m + s > 0
-})
+const showOverlay = computed(() => loading.value.any)
 ```
 
 ### Case 2: Edge case (shared owner id across components)


### PR DESCRIPTION
- Prune empty owner buckets in the tracking store so activeByOwner no
  longer grows unbounded across component/key mount/unmount cycles.
- Replace the per-track map spread with triggerRef and skip reactivity
  for no-op decrements (e.g. immediate watch firing with initial false).
- Count in-flight calls in useMutation and overlapping refetch/fetchMore/
  variable updates in useQuery so concurrent ops don't clear loading early.
- Namespace owner ids so a custom loadingKey can't collide with a uid.
- Add useGlobalLoading() and align loading-helper return types.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RhRZ9XBxdeL1Y8J6ifWpAC