### PR TITLE
fix(core): normalize useFragment result shape to avoid SSR hydration mismatch

### DIFF
--- a/.changeset/fix-usefragment-hydration-order.md
+++ b/.changeset/fix-usefragment-hydration-order.md
@@ -1,0 +1,7 @@
+---
+"@vue3-apollo/core": patch
+---
+
+Fix a Vue hydration mismatch when rendering the full `useFragment` result during SSR.
+
+The server prefetch path (`diffToResult`) and the client `watchFragment` subscription produced result objects with different key orders (`{ complete, data, dataState }` on the server vs `{ data, dataState, complete }` from Apollo's emission on the client). The values were identical, but serializing the whole result (e.g. `{{ result }}` in a template) made Vue report a hydration text mismatch. The client emission is now normalized to the same shape and key order as the server, keeping SSR and client output byte-identical.

--- a/packages/core/src/composables/useFragment.ts
+++ b/packages/core/src/composables/useFragment.ts
@@ -351,11 +351,28 @@ export function useFragment<TData = unknown, TVariables extends OperationVariabl
                         return
                     }
 
-                    result.value = value as UseFragmentResult<TData>
+                    // Normalize to the same key order/shape as the SSR prefetch path
+                    // (`diffToResult`). `watchFragment` emits its own object whose key
+                    // order (`data`, `dataState`, `complete`) differs from the server's
+                    // (`complete`, `data`, `dataState`); rendering the raw result then
+                    // produces a Vue hydration text mismatch even though the values are
+                    // identical. Rebuilding with a fixed key order keeps SSR and client
+                    // serialization byte-identical.
+                    const normalized = {
+                        complete: value.complete,
+                        data: value.data,
+                        dataState: value.dataState
+                    } as UseFragmentResult<TData>
+
+                    if (value.missing) {
+                        normalized.missing = value.missing
+                    }
+
+                    result.value = normalized
                     error.value = undefined
 
                     if (isDefined(value.data)) {
-                        void onResultEvent.trigger(value as UseFragmentResult<TData>, { client })
+                        void onResultEvent.trigger(normalized, { client })
                     }
                 }
             })


### PR DESCRIPTION
## Problem

When rendering the full `useFragment` result during SSR (e.g. `<pre>{{ result }}</pre>`), Vue reports a hydration mismatch:

```
[Vue warn]: Hydration text content mismatch on <pre>…</pre>
  - rendered on server: { "complete": true, "data": {…}, "dataState": "complete" }
  - expected on client: { "data": {…}, "dataState": "complete", "complete": true }
```

The **values are identical** — only the **key order** differs.

## Cause

Two code paths build the result object with different key orders:

- **Server** (`onServerPrefetch` → `diff()` → `diffToResult`): `{ complete, data, dataState }`.
- **Client**: `start()` subscribes to `client.watchFragment(...)`, which emits its own object synchronously. The `next` handler assigned that object directly (`result.value = value`), and Apollo's `WatchFragmentResult` is ordered `{ data, dataState, complete }`.

`{{ result }}` serializes via `JSON.stringify` (no key sorting), so the differing key order makes the `<pre>` text differ between SSR output and client runtime → hydration mismatch.

> In practice this only surfaces when serializing the *entire* result object; rendering individual fields (`data.title`, `complete`, …) is unaffected because the values match.

## Fix

Normalize the client `watchFragment` emission in `next` to the same shape and key order as the server path (`diffToResult`), so SSR and client serialization are byte-identical.

## Verification

- `pnpm --filter @vue3-apollo/core run typecheck` ✅
- `eslint packages/core/src/composables/useFragment.ts` ✅
- `pnpm build:core` ✅

Full in-browser hydration confirmation requires a headless browser run; the fix guarantees both paths emit `{ complete, data, dataState, missing? }` in the same order.

## Release

Includes a `@vue3-apollo/core` **patch** changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Zab6rhaD4bt8b4RA4NY19

---
_Generated by [Claude Code](https://claude.ai/code/session_018Zab6rhaD4bt8b4RA4NY19)_