### PR TITLE
Link @vue3-apollo/core and @vue3-apollo/nuxt as fixed packages

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.0.3/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [],
+  "fixed": [["@vue3-apollo/core", "@vue3-apollo/nuxt"]],
   "linked": [],
   "access": "public",
   "baseBranch": "main",


### PR DESCRIPTION
## Summary
Updated the changeset configuration to establish a fixed version relationship between `@vue3-apollo/core` and `@vue3-apollo/nuxt` packages, ensuring they are always released together with the same version number.

## Changes
- Modified `.changeset/config.json` to add `@vue3-apollo/core` and `@vue3-apollo/nuxt` to the `fixed` array
- This ensures that changes to either package will trigger a coordinated release of both packages at the same version

## Details
The fixed package configuration is useful for maintaining version parity between tightly coupled packages where the nuxt integration depends on the core package. This prevents version mismatches and simplifies dependency management for users of both packages.

https://claude.ai/code/session_018Zab6rhaD4bt8b4RA4NY19